### PR TITLE
feat(collapse): add parseInteger option

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains utilities for transforming and manipulating Falcor path
 
 ## Utility functions:
 
-* `collapse(paths)`<br>
+* `collapse(paths, [opts = { parseInteger: true }])`<br>
   Simplifies a set of paths. Example:
 
   ~~~js

--- a/lib/collapse.js
+++ b/lib/collapse.js
@@ -1,7 +1,12 @@
 var toPaths = require('./toPaths');
 var toTree = require('./toTree');
 
-module.exports = function collapse(paths) {
+module.exports = function collapse(paths, _opts) {
+    var opts = _opts || {};
+
+    // Enabled by default
+    opts.parseInteger = opts.parseInteger !== false;
+
     var collapseMap = paths.
         reduce(function(acc, path) {
             var len = path.length;
@@ -18,5 +23,5 @@ module.exports = function collapse(paths) {
             collapseMap[collapseKey] = toTree(collapseMap[collapseKey]);
         });
 
-    return toPaths(collapseMap);
+    return toPaths(collapseMap, opts);
 };

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ import type { Key, KeySet, PathSet, Path, JsonGraph, JsonGraphNode, JsonMap } fr
 export type PathTree = { [key: string]: PathTree | null | void };
 export type LengthTree = { [key: number]: PathTree | void };
 export type IteratorNote = { done?: boolean };
+export type CollapseOption = { parseInteger?: boolean = true };
 type FalcorPathUtils = {
     iterateKeySet(keySet: KeySet, note: IteratorNote): Key;
     toTree(paths: PathSet[]): PathTree;
@@ -16,7 +17,7 @@ type FalcorPathUtils = {
     toPaths(lengths: LengthTree): PathSet[];
     isIntegerKey(key: Key): boolean;
     maybeIntegerKey(key: Key): number | void;
-    collapse(paths: PathSet[]): PathSet[];
+    collapse(paths: PathSet[], opts?: CollapseOption): PathSet[];
     followReference(
         cacheRoot: JsonGraph,
         ref: Path,

--- a/lib/toPaths.js
+++ b/lib/toPaths.js
@@ -6,14 +6,14 @@ var typeOfString = "string";
 var typeOfNumber = "number";
 
 /* jshint forin: false */
-module.exports = function toPaths(lengths) {
+module.exports = function toPaths(lengths, opts) {
     var pathmap;
     var allPaths = [];
     var allPathsLength = 0;
     for (var length in lengths) {
         var num = maybeIntegerKey(length);
         if (typeof num === typeOfNumber && isObject(pathmap = lengths[length])) {
-            var paths = collapsePathMap(pathmap, 0, num).sets;
+            var paths = collapsePathMap(pathmap, 0, num, opts).sets;
             var pathsIndex = -1;
             var pathsCount = paths.length;
             while (++pathsIndex < pathsCount) {
@@ -28,7 +28,8 @@ function isObject(value) {
     return value !== null && typeof value === typeOfObject;
 }
 
-function collapsePathMap(pathmap, depth, length) {
+function collapsePathMap(pathmap, depth, length, _opts) {
+    var opts = _opts || {};
 
     var key;
     var code = getHashCode(String(depth));
@@ -56,7 +57,7 @@ function collapsePathMap(pathmap, depth, length) {
 
         while (++subKeysIndex < subKeysCount) {
             key = subKeys[subKeysIndex];
-            subPath = collapsePathMap(pathmap[key], depth + 1, length);
+            subPath = collapsePathMap(pathmap[key], depth + 1, length, opts);
             subCode = subPath.code;
             if(subs[subCode]) {
                 subPath = subs[subCode];
@@ -68,7 +69,7 @@ function collapsePathMap(pathmap, depth, length) {
                 };
             }
             code = getHashCode(code + key + subCode);
-            var num = maybeIntegerKey(key);
+            var num = opts.parseInteger ? maybeIntegerKey(key) : key;
             subPath.keys.push(typeof num === typeOfNumber ? num : key);
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "falcor-path-utils",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/collapse.spec.js
+++ b/test/collapse.spec.js
@@ -49,4 +49,18 @@ describe('collapse', function() {
             ['videos', { from: 1, to: 6}, 'summary']
         ]);
     });
+
+    it('should parse strings to integer by default', function() {
+            var result = collapse([['videosById', '1234', 'title']]);
+            expect(result).to.deep.equals([['videosById', 1234, 'title']]);
+    });
+
+    it('should not parse strings to integer with option', function() {
+            var result = collapse([['videosById', '1234', 'title']], {
+                    parseInteger: false
+            });
+            expect(result).to.deep.equals(
+                    [['videosById', '1234', 'title']]
+            );
+    });
 });


### PR DESCRIPTION
Make automatic string to integer parsing configurable *(it's enabled by default, no change for existing customers)*

Use-case: `['videosById', '123', 'title']` become `['videosById', 123, 'title']` after collapse.
In some places like in https://github.com/NetflixUI/nq-falcor-router we would like to preserve types to help Groovy comparison and keep consistency between user-input and output.
