### PR TITLE
fix(toTree): support reserved keyword

### DIFF
--- a/lib/toTree.js
+++ b/lib/toTree.js
@@ -1,5 +1,4 @@
 var iterateKeySet = require('./../lib/iterateKeySet');
-var isArray = Array.isArray;
 
 /**
  * @param {Array} paths -
@@ -21,8 +20,7 @@ function innerToTree(seed, path, depth) {
     key = iterateKeySet(keySet, iteratorNote);
 
     while (!iteratorNote.done) {
-
-        var next = seed[key];
+        var next = Object.hasOwnProperty.call(seed, key) && seed[key];
         if (!next) {
             if (nextDepth === path.length) {
                 seed[key] = null;

--- a/lib/toTree.js
+++ b/lib/toTree.js
@@ -20,7 +20,7 @@ function innerToTree(seed, path, depth) {
     key = iterateKeySet(keySet, iteratorNote);
 
     while (!iteratorNote.done) {
-        var next = Object.hasOwnProperty.call(seed, key) && seed[key];
+        var next = Object.prototype.hasOwnProperty.call(seed, key) && seed[key];
         if (!next) {
             if (nextDepth === path.length) {
                 seed[key] = null;

--- a/test/collapse.spec.js
+++ b/test/collapse.spec.js
@@ -20,6 +20,15 @@ describe('collapse', function() {
         ]);
     });
 
+    it('should collapse a path with reserved keyword.', function() {
+        var paths = [['foo', 'hasOwnProperty'], ['foo', 'constructor']];
+
+        var result = collapse(paths);
+        expect(result).to.eql([
+            ['foo', ['hasOwnProperty', 'constructor']]
+        ]);
+    });
+
     it('should collapse paths with mixed adjacents', function() {
         var paths = [
             ['videosById', 1, 'title'],

--- a/test/toTree.spec.js
+++ b/test/toTree.spec.js
@@ -10,6 +10,13 @@ describe('toTree', function() {
         expect(toTree([input])).to.deep.equals(out);
     });
 
+    it('should explode a simplePath with reserved keyword.', function() {
+        var input = ['one', 'hasOwnProperty'];
+        var out = {one: {hasOwnProperty: null}};
+
+        expect(toTree([input])).to.deep.equals(out);
+    });
+
     it('should explode a complex.', function() {
         var input = ['one', ['two', 'three']];
         var out = {one: {three: null, two: null}};


### PR DESCRIPTION
collapse returned an empty array for reserved keywords.