### PR TITLE
fix(toTree): handle empty path

### DIFF
--- a/lib/toTree.js
+++ b/lib/toTree.js
@@ -24,7 +24,7 @@ function innerToTree(seed, path, depth) {
         if (!next) {
             if (nextDepth === path.length) {
                 seed[key] = null;
-            } else {
+            } else if (key !== undefined) {
                 next = seed[key] = {};
             }
         }

--- a/test/toTree.spec.js
+++ b/test/toTree.spec.js
@@ -10,6 +10,13 @@ describe('toTree', function() {
         expect(toTree([input])).to.deep.equals(out);
     });
 
+    it('should explode an empty path.', function() {
+        var input = [];
+        var out = {};
+
+        expect(toTree([input])).to.deep.equals(out);
+    });
+
     it('should explode a simplePath with reserved keyword.', function() {
         var input = ['one', 'hasOwnProperty'];
         var out = {one: {hasOwnProperty: null}};


### PR DESCRIPTION
Handle empty path correctly in `toTree`.