### PR TITLE
Use NOINLINE to avoid inlining function definitions

### DIFF
--- a/lib/iterateKeySet.js
+++ b/lib/iterateKeySet.js
@@ -18,7 +18,7 @@ var isArray = Array.isArray;
  */
 module.exports = function iterateKeySet(keySet, note) {
     if (note.isArray === undefined) {
-        initializeNote(keySet, note);
+        /*#__NOINLINE__*/ initializeNote(keySet, note);
     }
 
     // Array iteration

--- a/lib/toPaths.js
+++ b/lib/toPaths.js
@@ -2,14 +2,12 @@ var maybeIntegerKey = require("./integerKey").maybeIntegerKey;
 var isIntegerKey = require("./integerKey").isIntegerKey;
 var isArray = Array.isArray;
 var typeOfObject = "object";
-var typeOfString = "string";
 var typeOfNumber = "number";
 
 /* jshint forin: false */
 module.exports = function toPaths(lengths) {
     var pathmap;
     var allPaths = [];
-    var allPathsLength = 0;
     for (var length in lengths) {
         var num = maybeIntegerKey(length);
         if (typeof num === typeOfNumber && isObject(pathmap = lengths[length])) {
@@ -17,7 +15,7 @@ module.exports = function toPaths(lengths) {
             var pathsIndex = -1;
             var pathsCount = paths.length;
             while (++pathsIndex < pathsCount) {
-                allPaths[allPathsLength++] = collapsePathSetIndexes(paths[pathsIndex]);
+                allPaths.push(collapsePathSetIndexes(paths[pathsIndex]));
             }
         }
     }

--- a/lib/toTree.js
+++ b/lib/toTree.js
@@ -5,11 +5,13 @@ var iterateKeySet = require('./../lib/iterateKeySet');
  * @returns {Object} -
  */
 module.exports = function toTree(paths) {
-    return paths.reduce(function(acc, path) {
-        innerToTree(acc, path, 0);
-        return acc;
-    }, {});
+    return paths.reduce(__reducer, {});
 };
+
+function __reducer(acc, path) {
+    /*#__NOINLINE__*/ innerToTree(acc, path, 0);
+    return acc;
+}
 
 function innerToTree(seed, path, depth) {
     var keySet = path[depth];


### PR DESCRIPTION
Currently some simple function declarations will have the entire function body inlined by terser, which is inefficient. This change is necessary because terser deprecated the reduce_funcs option, which prevented this behavior before. 

https://github.com/terser/terser/issues/696